### PR TITLE
Fix platforms list

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,7 +17,7 @@
     "homepage": "https://github.com/boeserfrosch/GuL_TI_Humidity",
     "license": "GPL-3.0-or-later",
     "frameworks": "arduino",
-    "platforms": ["esp8266", "esp32"],
+    "platforms": ["espressif8266", "espressif32"],
     "headers": ["HDC1010.h", "HDC1080.h"],
     "examples": "examples/*/*.ino"
 }


### PR DESCRIPTION
My apologies; this corrects a mismatch in the `library.json` file with how `platforms` is defined versus how it is defined in the `library.properties` file. It is a minor change but I still apologize for introducing the error in the first place.

If after merging you could create a new release tag for version 1.1.2 that would be fantastic! Thank you very much!